### PR TITLE
ci: add Windows to CI matrix; validate install + merge round-trip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Keep committed JS/TS at LF on disk regardless of platform autocrlf settings.
+# The shebang in dist/src/cli.js must stay LF — Node on Linux/macOS won't
+# parse "#!/usr/bin/env node\r" correctly, so a Windows checkout that
+# normalized to CRLF and was then published would break the published binary.
+*.js text eol=lf
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Configure git (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.symlinks false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -28,6 +38,7 @@ jobs:
         run: npm test
 
       - name: Verify committed dist is up to date
+        if: runner.os == 'Linux'
         run: |
           npm run build
           git diff --exit-code dist/ \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ git config merge.journal.driver \
 git config merge.journal.name 'JSON keyed-array append merger'
 ```
 
+The double-quotes around `%O`, `%A`, `%B` are deliberate: git substitutes those placeholders with paths to its temporary blobs, and on Windows those paths can contain spaces (e.g., when the repo lives under `C:\Users\Some Name\...`). Git invokes the driver string through `/bin/sh` on Unix and through Git for Windows' bundled MSYS `sh` on Windows, so POSIX double-quote semantics apply on both platforms — no additional escaping is needed.
+
 ## CLI
 
 ```
@@ -134,7 +136,7 @@ Structural equality is canonical (key-order-insensitive) — `{a: 1, b: 2}` and 
 
 **Concurrent merges still conflict on `_journal.json`.** Confirm `.git/config` actually has `merge.<name>.driver` set (`git config --get merge.journal.driver`). Driver definitions live there and aren't committed — each collaborator must run `install` once after cloning.
 
-**Driver invocation fails on Windows.** v1 only validates macOS and Ubuntu. The known footgun is `git config` argument quoting in `install.ts`. Tracked as issue #10.
+**Driver invocation fails on Windows.** Confirm `git-merge-append` resolves on the shell git invokes for merge drivers. On Windows that's Git for Windows' bundled MSYS `sh`; running `which git-merge-append` from Git Bash should print the npm-installed wrapper. If it doesn't, your `npm bin -g` directory isn't on the PATH that Git Bash sees.
 
 ## Non-goals
 

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,31 +1,55 @@
-// Real-git integration test. Skipped on Windows for v1: the install command's
-// shell-quoting story for `git config merge.<name>.driver` on Windows isn't
-// validated yet (tracked as issue #10).
+// Real-git integration test exercising the install + driver round-trip.
+//
+// On Windows, git invokes merge drivers through its bundled MSYS sh, so the
+// no-extension POSIX wrapper script we drop on PATH is what git actually runs
+// — the .cmd shim is only there for direct invocations from cmd/PowerShell
+// (which our tests don't do; they spawn node directly with the CLI path).
 
 import { describe, it, expect } from "vitest";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir, platform } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 
 const CLI_PATH = join(__dirname, "..", "dist", "src", "cli.js");
 const isWindows = platform() === "win32";
-const skipDescribe = isWindows ? describe.skip : describe;
 
 // Provides a 'git-merge-append' binary on PATH that proxies to the built CLI.
 // This lets the install command register a driver that git can find when it
 // invokes the merge driver during git merge / git rebase.
-function setUp(): { dir: string; env: NodeJS.ProcessEnv } {
-  const dir = mkdtempSync(join(tmpdir(), "git-merge-append-it-"));
+function setUp(opts: { dirSuffix?: string } = {}): {
+  dir: string;
+  env: NodeJS.ProcessEnv;
+} {
+  const dir = mkdtempSync(join(tmpdir(), opts.dirSuffix ?? "git-merge-append-it-"));
   const binDir = join(dir, "bin");
-  spawnSync("mkdir", ["-p", binDir]);
-  const wrapperBin = join(binDir, "git-merge-append");
-  writeFileSync(wrapperBin, `#!/bin/sh\nexec node "${CLI_PATH}" "$@"\n`);
-  chmodSync(wrapperBin, 0o755);
+  mkdirSync(binDir, { recursive: true });
+
+  // POSIX shell wrapper — used by git's MSYS sh on Windows and by /bin/sh on
+  // Unix. The CLI path is single-quoted so spaces in node_modules paths don't
+  // break it.
+  const shWrapper = join(binDir, "git-merge-append");
+  writeFileSync(shWrapper, `#!/bin/sh\nexec node '${CLI_PATH}' "$@"\n`);
+  chmodSync(shWrapper, 0o755);
+
+  if (isWindows) {
+    // .cmd shim for cmd.exe lookups (PATHEXT). Not strictly needed for these
+    // tests, but matches what `npm install -g git-merge-append` actually drops
+    // on PATH, so the test environment more closely mirrors a real install.
+    const cmdWrapper = join(binDir, "git-merge-append.cmd");
+    writeFileSync(cmdWrapper, `@echo off\r\nnode "${CLI_PATH}" %*\r\n`);
+  }
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
     GIT_AUTHOR_NAME: "Test",
     GIT_AUTHOR_EMAIL: "test@example.com",
     GIT_COMMITTER_NAME: "Test",
@@ -37,9 +61,12 @@ function setUp(): { dir: string; env: NodeJS.ProcessEnv } {
   return { dir, env };
 }
 
-function run(args: readonly string[], opts: { env: NodeJS.ProcessEnv; allowFail?: boolean } & {
-  cwd?: string;
-} = { env: process.env }): SpawnSyncReturns<string> {
+function run(
+  args: readonly string[],
+  opts: { env: NodeJS.ProcessEnv; allowFail?: boolean } & {
+    cwd?: string;
+  } = { env: process.env },
+): SpawnSyncReturns<string> {
   const r = spawnSync("git", args, { encoding: "utf8", env: opts.env, cwd: opts.cwd });
   if (!opts.allowFail && r.status !== 0) {
     throw new Error(`git ${args.join(" ")} failed:\n${r.stderr}\n${r.stdout}`);
@@ -51,7 +78,7 @@ function wrap(entries: unknown[]): string {
   return JSON.stringify({ version: "5", entries }, null, 2) + "\n";
 }
 
-skipDescribe("real-git integration", () => {
+describe("real-git integration", () => {
   it("sanity: built CLI exists", () => {
     expect(existsSync(CLI_PATH)).toBe(true);
   });
@@ -96,6 +123,57 @@ skipDescribe("real-git integration", () => {
     run(["-C", dir, "commit", "-q", "-am", "append idx=2"], { env });
 
     // Merge branch-a into branch-b — should resolve cleanly via the driver.
+    const mergeR = run(["-C", dir, "merge", "-q", "--no-edit", "branch-a"], { env, allowFail: true });
+    expect(mergeR.status, `merge failed:\n${mergeR.stderr}\n${mergeR.stdout}`).toBe(0);
+
+    const merged = JSON.parse(readFileSync(journalPath, "utf8"));
+    expect(merged.entries).toEqual([
+      { idx: 0, tag: "init" },
+      { idx: 1, tag: "a" },
+      { idx: 2, tag: "b" },
+    ]);
+  });
+
+  // The Windows footgun is `git config merge.<name>.driver` quoting once a
+  // path with a space gets involved. Here we drop the repo into a tmp dir
+  // whose name contains a space — that affects $PATH lookup for the wrapper
+  // script and the absolute CLI path string the driver invocation eventually
+  // expands to. If the driver string round-trips correctly through git config
+  // and sh, the merge below resolves cleanly.
+  it("handles a working tree path that contains a space", () => {
+    const { dir, env } = setUp({ dirSuffix: "git-merge-append it " });
+    const journal = "_journal.json";
+    const journalPath = join(dir, journal);
+    writeFileSync(journalPath, wrap([{ idx: 0, tag: "init" }]));
+    run(["-C", dir, "add", journal], { env });
+    run(["-C", dir, "commit", "-q", "-m", "init"], { env });
+
+    const installR = spawnSync(
+      process.execPath,
+      [
+        CLI_PATH, "install",
+        "--name", "journal",
+        "--array-path", "entries",
+        "--key", "idx",
+        "--sort-by", "idx",
+        "--", journal,
+      ],
+      { cwd: dir, env, encoding: "utf8" },
+    );
+    expect(installR.status, installR.stderr).toBe(0);
+
+    run(["-C", dir, "add", ".gitattributes"], { env });
+    run(["-C", dir, "commit", "-q", "-m", "add gitattributes"], { env });
+
+    run(["-C", dir, "checkout", "-q", "-b", "branch-a"], { env });
+    writeFileSync(journalPath, wrap([{ idx: 0, tag: "init" }, { idx: 1, tag: "a" }]));
+    run(["-C", dir, "commit", "-q", "-am", "append idx=1"], { env });
+
+    run(["-C", dir, "checkout", "-q", "main"], { env });
+    run(["-C", dir, "checkout", "-q", "-b", "branch-b"], { env });
+    writeFileSync(journalPath, wrap([{ idx: 0, tag: "init" }, { idx: 2, tag: "b" }]));
+    run(["-C", dir, "commit", "-q", "-am", "append idx=2"], { env });
+
     const mergeR = run(["-C", dir, "merge", "-q", "--no-edit", "branch-a"], { env, allowFail: true });
     expect(mergeR.status, `merge failed:\n${mergeR.stderr}\n${mergeR.stdout}`).toBe(0);
 


### PR DESCRIPTION
## Summary

- Adds `windows-latest` alongside `ubuntu-latest` in the CI matrix; gates the dist-up-to-date check to Linux only (its diff is sh-based and CRLF-sensitive).
- Drops the Windows skip from the real-git integration test by replacing POSIX-only assumptions (`mkdir -p`, hard-coded `:` PATH separator) with cross-platform equivalents.
- Writes a `.cmd` shim alongside the no-extension shell wrapper so the test bin dir mirrors what `npm install -g git-merge-append` actually drops on PATH on Windows.
- Adds a fixture that runs the install + concurrent-append merge inside a tmp dir whose name contains a space — the typical Windows footgun for `git config merge.<name>.driver` quoting.
- Updates README: removes the v1 "validated only on macOS/Ubuntu" caveat and documents that the `%O`/`%A`/`%B` double-quoting is what makes paths-with-spaces work uniformly through `/bin/sh` on Unix and Git for Windows' MSYS `sh`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes locally on macOS (75/75)
- [ ] CI green on `ubuntu-latest`
- [ ] CI green on `windows-latest` — the actual validation goal

Closes #10