### PR TITLE
review: tighten .gitattributes scope and clarify space-in-path test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
-# Keep committed JS/TS at LF on disk regardless of platform autocrlf settings.
-# The shebang in dist/src/cli.js must stay LF — Node on Linux/macOS won't
-# parse "#!/usr/bin/env node\r" correctly, so a Windows checkout that
-# normalized to CRLF and was then published would break the published binary.
-*.js text eol=lf
-*.ts text eol=lf
-*.json text eol=lf
-*.md text eol=lf
-*.yml text eol=lf
+# Pin published-binary and shell-script line endings to LF on disk regardless
+# of platform autocrlf settings. The shebang in dist/src/cli.js must stay LF
+# — Node on Linux/macOS won't parse "#!/usr/bin/env node\r", so a Windows
+# checkout that normalized to CRLF and was then published would break the
+# published binary. Same reasoning applies pre-emptively to any future shell
+# scripts we ship.
+#
+# Other text formats (test fixtures, JSON, docs) are intentionally left to
+# git's default behavior so a contributor can commit a CRLF fixture without
+# having it silently normalized.
+dist/**/*.js text eol=lf
+*.sh text eol=lf

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -134,12 +134,16 @@ describe("real-git integration", () => {
     ]);
   });
 
-  // The Windows footgun is `git config merge.<name>.driver` quoting once a
-  // path with a space gets involved. Here we drop the repo into a tmp dir
-  // whose name contains a space — that affects $PATH lookup for the wrapper
-  // script and the absolute CLI path string the driver invocation eventually
-  // expands to. If the driver string round-trips correctly through git config
-  // and sh, the merge below resolves cleanly.
+  // The Windows footgun is paths with spaces interacting with the shell git
+  // uses to invoke merge drivers. Dropping the repo into a tmp dir whose name
+  // contains a space exercises two failure modes specifically: (a) PATH
+  // lookup of the `git-merge-append` shim from MSYS sh when binDir's parent
+  // contains a space, and (b) git substituting %O/%A/%B with paths under the
+  // spaced working tree, which sh re-interprets through the double-quoted
+  // placeholders in the persisted driver string. The driver string itself is
+  // path-independent (no cwd-derived bytes), so storage round-tripping isn't
+  // what's under test here — that would require a flag value containing a
+  // space, which is a worthwhile follow-up but outside this fixture's scope.
   it("handles a working tree path that contains a space", () => {
     const { dir, env } = setUp({ dirSuffix: "git-merge-append it " });
     const journal = "_journal.json";


### PR DESCRIPTION
## Summary

- Narrows `.gitattributes` from `*.js/*.ts/*.json/*.md/*.yml` repo-wide to `dist/**/*.js` (the actual concern: shebang CRLF on Windows publish) plus `*.sh` for any future shell scripts. Other text formats are intentionally left to git's default so a contributor can commit a CRLF fixture without it being silently normalized — important because the merger has explicit CRLF-preservation semantics covered by `__tests__/json-array.test.ts`.
- Rewrites the comment on the space-in-path integration test. The persisted driver string is cwd-independent, so the test isn't covering driver-string storage round-tripping (as the old comment implied) — it's covering PATH lookup through MSYS sh and `%O`/`%A`/`%B` substitution under a spaced working tree. Updated comment says so.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes locally on macOS (75/75)
- [ ] CI green on `ubuntu-latest`
- [ ] CI green on `windows-latest`

Closes #14