### PR TITLE
ci+docs: forward-compat dist gate; use command -v over which

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm test
 
       - name: Verify committed dist is up to date
-        if: runner.os == 'Linux'
+        if: runner.os != 'Windows'
         run: |
           npm run build
           git diff --exit-code dist/ \

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Structural equality is canonical (key-order-insensitive) — `{a: 1, b: 2}` and 
 
 **Concurrent merges still conflict on `_journal.json`.** Confirm `.git/config` actually has `merge.<name>.driver` set (`git config --get merge.journal.driver`). Driver definitions live there and aren't committed — each collaborator must run `install` once after cloning.
 
-**Driver invocation fails on Windows.** Confirm `git-merge-append` resolves on the shell git invokes for merge drivers. On Windows that's Git for Windows' bundled MSYS `sh`; running `which git-merge-append` from Git Bash should print the npm-installed wrapper. If it doesn't, your `npm bin -g` directory isn't on the PATH that Git Bash sees.
+**Driver invocation fails on Windows.** Confirm `git-merge-append` resolves on the shell git invokes for merge drivers. On Windows that's Git for Windows' bundled MSYS `sh`; running `command -v git-merge-append` from Git Bash should print the npm-installed wrapper. If it doesn't, your `npm bin -g` directory isn't on the PATH that Git Bash sees.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- Flip the dist-up-to-date CI gate from `runner.os == 'Linux'` to `runner.os != 'Windows'` so a future `macos-latest` row doesn't silently skip the check.
- Replace `which` with `command -v` in the Windows troubleshooting paragraph — `which` isn't a POSIX builtin; `command -v` is and works in the same MSYS sh that git invokes for merge drivers.

## Test plan

- [ ] CI green on `ubuntu-latest` (dist-verify still runs)
- [ ] CI green on `windows-latest` (dist-verify still skips)

Closes #19